### PR TITLE
gnp.py: Add use_cfi_icall=false if is official build

### DIFF
--- a/misc/gnp.py
+++ b/misc/gnp.py
@@ -269,7 +269,7 @@ examples:
 
             gn_args += ' enable_nacl=false proprietary_codecs=true chrome_pgo_phase=0'
             if self.args.no_component_build:
-                gn_args += ' is_official_build=true'
+                gn_args += ' is_official_build=true use_cfi_icall=false'
 
         quotation = Util.get_quotation()
         cmd = 'gn --args=%s%s%s' % (quotation, gn_args, quotation)


### PR DESCRIPTION
When is_official_build is true, Dawn requires use_cfi_icall is false
because it dynamically loads function pointers and isn't sanitized yet.