### PR TITLE
gputest.py: Add WebGPU telemetry harness tests

### DIFF
--- a/misc/gnp.py
+++ b/misc/gnp.py
@@ -51,6 +51,7 @@ class Gnp(Program):
         'vulkan_tests': '//gpu/vulkan:vulkan_tests',
         'telemetry_gpu_integration_test': '//chrome/test:telemetry_gpu_integration_test',
         'webgl': '//chrome/test:telemetry_gpu_integration_test',
+        'webgpu_cts_tests': '//chrome/test:telemetry_gpu_integration_test',
         'webgpu_blink_web_tests': '//:webgpu_blink_web_tests',
         'webgpu': '//:webgpu_blink_web_tests',
     }
@@ -386,6 +387,7 @@ examples:
                 'out/%s/args.gn' % self.build_type_cap,
                 'out/%s/../../testing/buildbot/chromium.gpu.fyi.json' % self.build_type_cap,
                 'out/%s/../../testing/buildbot/chromium.dawn.json' % self.build_type_cap,
+                'out/%s/../../content/test/gpu/.webgpu_typescript/' % self.build_type_cap,
             ]
 
         src_file_count = len(src_files)

--- a/misc/gputest.py
+++ b/misc/gputest.py
@@ -101,6 +101,8 @@ class GPUTest(Program):
         'webgl_conformance_gl_passthrough_tests': ['telemetry_gpu_integration_test', 'conformance/attribs'],
         'webgl_conformance_validating_tests': ['telemetry_gpu_integration_test', 'conformance/attribs'],
         'webgl_conformance_vulkan_passthrough_tests': ['telemetry_gpu_integration_test', 'conformance/attribs'],
+        'webgpu_cts_tests': ['telemetry_gpu_integration_test', 'webgpu:idl,constants,flags:*'],
+        'webgpu_cts_with_validation_tests': ['telemetry_gpu_integration_test', 'webgpu:idl,constants,flags:*'],
 
         'webgpu_blink_web_tests': ['webgpu_blink_web_tests', 'wpt_internal/webgpu/cts.https.html?q=webgpu:api,operation,resource_init,texture_zero:uninitialized_texture_is_zero:*'],
         # Virtual name on Linux


### PR DESCRIPTION
- Add more resources required by WebGPU telemetry tests to build binary
- Add target name: webgpu_cts_tests and webgpu_cts_with_validation_tests
- Not remove old WebGPU CTS because the new one is not fully enabled,
  just some examples and idl tests are enabled.