### PR TITLE
mesa.py: Remove libkms from drm build

### DIFF
--- a/misc/mesa.py
+++ b/misc/mesa.py
@@ -163,7 +163,7 @@ examples:
         Util.chdir('%s/%s' % (self.root_dir, self.drm_dir))
         Util.ensure_nodir('build')
         Util.ensure_dir('build')
-        build_cmd = 'meson build/ -Dprefix=%s -Dlibkms=true -Dintel=true -Dvmwgfx=false -Dradeon=false -Damdgpu=false -Dnouveau=false' % rev_dir
+        build_cmd = 'meson build/ -Dprefix=%s -Dintel=true -Dvmwgfx=false -Dradeon=false -Damdgpu=false -Dnouveau=false' % rev_dir
         if self.build_type == 'release':
             build_cmd += ' -Dbuildtype=release'
         elif self.build_type == 'debug':


### PR DESCRIPTION
Failed to build mesa drm due to libkms had been removed:
https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/229