### PR TITLE
gputest.py: Revert unstaged/untracked changes in sync()

### DIFF
--- a/misc/gputest.py
+++ b/misc/gputest.py
@@ -210,7 +210,7 @@ examples:
         for project in self.projects:
             timer = Timer()
             root_dir = self.PROJECT_INFO[project][self.PROJECT_INFO_INDEX_ROOT_DIR]
-            cmd = '%s %s --root-dir %s --sync --runhooks' % (Util.PYTHON, Util.GNP_SCRIPT, root_dir)
+            cmd = '%s %s --root-dir %s --sync --sync-reset --runhooks' % (Util.PYTHON, Util.GNP_SCRIPT, root_dir)
             dryrun = self.args.dryrun
             if self._execute(cmd, exit_on_error=False, dryrun=dryrun)[0]:
                 error_info = 'Project %s sync failed' % project


### PR DESCRIPTION
There may be some unstaged or untracked changes left in the repo
when git pull failed or stopped unexpected, it will block code sync
next time.