### PR TITLE
gnp.py: Fix bot mode in angle_white_box_tests

### DIFF
--- a/misc/gnp.py
+++ b/misc/gnp.py
@@ -613,9 +613,9 @@ examples:
             if target not in ['telemetry_gpu_integration_test', 'webgpu_blink_web_tests']:
                 cmd = './' + cmd
 
-        if target == 'angle_end2end_tests':
+        if target in ['angle_end2end_tests', 'angle_white_box_tests']:
             if 'bot-mode' not in cmd:
-                cmd += ' --bot-mode'
+                cmd += ' --test-launcher-bot-mode'
 
         if target == 'dawn_end2end_tests':
             if 'exclusive-device-type-preference' not in cmd:

--- a/misc/gnp.py
+++ b/misc/gnp.py
@@ -615,7 +615,6 @@ examples:
 
         if target in ['angle_end2end_tests', 'angle_white_box_tests']:
             if 'test-launcher-bot-mode' not in cmd:
-
                 cmd += ' --test-launcher-bot-mode'
 
         if target == 'dawn_end2end_tests':

--- a/misc/gnp.py
+++ b/misc/gnp.py
@@ -614,7 +614,8 @@ examples:
                 cmd = './' + cmd
 
         if target in ['angle_end2end_tests', 'angle_white_box_tests']:
-            if 'bot-mode' not in cmd:
+            if 'test-launcher-bot-mode' not in cmd:
+
                 cmd += ' --test-launcher-bot-mode'
 
         if target == 'dawn_end2end_tests':


### PR DESCRIPTION
The result of angle_white_box_tests fails to be written into output.json because '--bot-mode' is removed from angle.json and instead using chrome-based wrapper script to pass --test-launcher-bot-mode.
Upstream CL: https://chromium-review.googlesource.com/c/angle/angle/+/3399045