### PR TITLE
mesa.py: Add glslang-tools dependency

### DIFF
--- a/misc/mesa.py
+++ b/misc/mesa.py
@@ -82,7 +82,7 @@ examples:
         self._init_hash()
 
         if Util.HOST_OS == 'linux' and Util.HOST_OS_RELEASE == 'ubuntu':
-            Util.ensure_pkg('meson libomxil-bellagio-dev libpciaccess-dev x11proto-dri3-dev x11proto-present-dev xutils-dev python-mako x11proto-gl-dev x11proto-dri2-dev libxcb-dri3-dev libxcb-present-dev libxshmfence-dev libx11-xcb-dev libxcb-glx0-dev libxcb-dri2-0-dev libxxf86vm-dev python3-mako')
+            Util.ensure_pkg('meson libomxil-bellagio-dev libpciaccess-dev x11proto-dri3-dev x11proto-present-dev xutils-dev python-mako x11proto-gl-dev x11proto-dri2-dev libxcb-dri3-dev libxcb-present-dev libxshmfence-dev libx11-xcb-dev libxcb-glx0-dev libxcb-dri2-0-dev libxxf86vm-dev python3-mako glslang-tools')
 
         if re.search('-', str(self.rev)):
             tmp_revs = self.rev.split('-')


### PR DESCRIPTION
Mesa build requires glslValidator for softtp64 workaround on ICL/TGL: https://gitlab.freedesktop.org/mesa/mesa/-/commit/9786d9ef2abb45a4e832cf1347581e3ca3aae9f0