### PR TITLE
gputest.py: Continue gpu tests when Mesa build fails

### DIFF
--- a/misc/gputest.py
+++ b/misc/gputest.py
@@ -294,7 +294,7 @@ examples:
                 if self._execute(cmd, exit_on_error=False, dryrun=dryrun)[0]:
                     error_info = 'Project Mesa build failed'
                     self._send_email(subject=error_info)
-                    Util.error(error_info)
+                    Util.warning(error_info)
                 rev_name, _ = Util.set_mesa(Util.PROJECT_MESA_BACKUP_DIR, self.args.run_mesa_rev)
 
             else:

--- a/misc/mesa.py
+++ b/misc/mesa.py
@@ -105,7 +105,8 @@ examples:
             if i % self.args.rev_stride:
                 i += 1
                 continue
-            self._build_one(i, self._rev_to_hash(i))
+            if not self._build_one(i, self._rev_to_hash(i)) and min_rev == max_rev:
+                Util.error('Failed to build revision %s' % i)
             i += 1
 
     def upload(self):
@@ -170,8 +171,7 @@ examples:
             build_cmd += ' -Dbuildtype=debug'
         build_cmd += ' && ninja -j%s -C build/ install' % Util.CPU_COUNT
 
-        result = self._execute(build_cmd)
-        if result[0]:
+        if self._execute(build_cmd, exit_on_error=False)[0]:
             Util.ensure_nodir(rev_dir)
             return False
 
@@ -189,8 +189,7 @@ examples:
             build_cmd += ' -Dbuildtype=debug'
         build_cmd += ' && ninja -j%s -C build/ install' % Util.CPU_COUNT
 
-        result = self._execute(build_cmd)
-        if result[0]:
+        if self._execute(build_cmd, exit_on_error=False)[0]:
             Util.ensure_nodir(rev_dir)
             return False
 


### PR DESCRIPTION
Continue gpu tests exection with last successful Mesa build if the latest Mesa build fails.