### PR TITLE
gputest.py: Update slow_tests.txt in webgpu_cts_tests

### DIFF
--- a/misc/chrome-drop.py
+++ b/misc/chrome-drop.py
@@ -387,8 +387,9 @@ examples:
                 self.chrome_rev = self.run_chrome_rev
                 (chrome_rev_dir, self.chrome_rev) = Util.get_backup_dir(self.chrome_backup_dir, self.chrome_rev)
                 chrome_rev_dir = f'{self.chrome_backup_dir}/{chrome_rev_dir}'
-                # Locally update expectations.txt in webgpu_cts_tests
+                # Locally update expectations.txt and slow_tests.txt in webgpu_cts_tests
                 Util.update_gpu_test_expectations(f'{chrome_rev_dir}/third_party/dawn/webgpu-cts/expectations.txt')
+                Util.update_gpu_test_expectations(f'{chrome_rev_dir}/third_party/dawn/webgpu-cts/slow_tests.txt')
                 Util.chdir(chrome_rev_dir, verbose=True)
                 Util.info(f'Use Chrome at {chrome_rev_dir}')
 

--- a/misc/gputest.py
+++ b/misc/gputest.py
@@ -346,9 +346,10 @@ examples:
             if skip:
                 continue
 
-            # Locally update expectations.txt in webgpu_cts_tests
+            # Locally update expectations.txt and slow_tests.txt in webgpu_cts_tests
             if virtual_name == 'webgpu_cts_tests':
                 Util.update_gpu_test_expectations(f'{project_run_root_dir}/third_party/dawn/webgpu-cts/expectations.txt')
+                Util.update_gpu_test_expectations(f'{project_run_root_dir}/third_party/dawn/webgpu-cts/slow_tests.txt')
             # Locally update expectations.txt in trace_test
             if virtual_name == 'trace_test':
                 Util.update_gpu_test_expectations(f'{project_run_root_dir}/content/test/gpu/gpu_tests/test_expectations/trace_test_expectations.txt')


### PR DESCRIPTION
The slow tests of WebGPU CTS are moved to separate expectation file named slow_tests.txt.

 Also update it in chrome-drop.py.