### PR TITLE
gnp.py: git pull without submodule update in angle and chromium

### DIFF
--- a/misc/gnp.py
+++ b/misc/gnp.py
@@ -231,7 +231,7 @@ examples:
             if self.decimal_rev:
                 self._chromium_sync_decimal_rev()
         else:
-            self._execute('git pull', exit_on_error=self.exit_on_error)
+            self._execute('git pull --no-recurse-submodules', exit_on_error=self.exit_on_error)
             self._execute_gclient(cmd_type='sync')
 
     def runhooks(self):
@@ -562,7 +562,7 @@ examples:
         if tmp_hash:
             extra_cmd = '--revision src@' + tmp_hash
         else:
-            self._execute('git pull', exit_on_error=self.exit_on_error)
+            self._execute('git pull --no-recurse-submodules', exit_on_error=self.exit_on_error)
             extra_cmd = ''
 
         if not self.args.sync_src_only:


### PR DESCRIPTION
Angle and Chromium projects added .gitmodules which makes 'git pull'
failed to update submodule because we set submodule recurse with true
globally, but some modules depend on chrome-internal sources.

These modules are kept in sync with commits in DEPS, no need to update
them in git pull.