### PR TITLE
gputest.py: Remove unused _parse_result call

### DIFF
--- a/misc/gputest.py
+++ b/misc/gputest.py
@@ -448,7 +448,6 @@ examples:
                         shutil.move(output_file, result_file)
                     else:
                         Util.ensure_file(result_file)
-                self._parse_result(result_file, verbose=True)
                 if args.dryrun and not args.dryrun_with_shard:
                     break
 


### PR DESCRIPTION
All results parse will be called in _report.