### PR TITLE
testhelper.py: Add expectations for WebGPU CTS

### DIFF
--- a/misc/testhelper.py
+++ b/misc/testhelper.py
@@ -69,7 +69,14 @@ class TestExpectation:
         ],
         'third_party/dawn/webgpu-cts/expectations.txt': [
             'crbug.com/1301808 [ intel ubuntu ] webgpu:web_platform,canvas,configure:viewFormats:canvasType="onscreen";format="rgba16float";* [ Failure ]',
-            'crbug.com/1301808 [ intel ubuntu ] webgpu:web_platform,canvas,configure:viewFormats:canvasType="offscreen";format="rgba16float";* [ Failure ]'
+            'crbug.com/1301808 [ intel ubuntu ] webgpu:web_platform,canvas,configure:viewFormats:canvasType="offscreen";format="rgba16float";* [ Failure ]',
+            # Tracking at https://github.com/webatintel/webconformance/issues/26
+            'crbug.com/0000 [ intel webgpu-adapter-default ] webgpu:web_platform,external_texture,video:importExternalTexture,sampleWithVideoFrameWithVisibleRectParam:videoName="four-colors-h264-bt601-rotate-180.mp4";dstColorSpace="display-p3" [ Failure ]',
+            'crbug.com/0000 [ intel webgpu-adapter-default ] webgpu:web_platform,external_texture,video:importExternalTexture,sampleWithVideoFrameWithVisibleRectParam:videoName="four-colors-h264-bt601-rotate-180.mp4";dstColorSpace="srgb" [ Failure ]',
+            'crbug.com/0000 [ intel webgpu-adapter-default ] webgpu:web_platform,external_texture,video:importExternalTexture,sampleWithVideoFrameWithVisibleRectParam:videoName="four-colors-h264-bt601-rotate-270.mp4";dstColorSpace="display-p3" [ Failure ]',
+            'crbug.com/0000 [ intel webgpu-adapter-default ] webgpu:web_platform,external_texture,video:importExternalTexture,sampleWithVideoFrameWithVisibleRectParam:videoName="four-colors-h264-bt601-rotate-270.mp4";dstColorSpace="srgb" [ Failure ]',
+            'crbug.com/0000 [ intel webgpu-adapter-default ] webgpu:web_platform,external_texture,video:importExternalTexture,sampleWithVideoFrameWithVisibleRectParam:videoName="four-colors-h264-bt601-rotate-90.mp4";dstColorSpace="display-p3" [ Failure ]',
+            'crbug.com/0000 [ intel webgpu-adapter-default ] webgpu:web_platform,external_texture,video:importExternalTexture,sampleWithVideoFrameWithVisibleRectParam:videoName="four-colors-h264-bt601-rotate-90.mp4";dstColorSpace="srgb" [ Failure ]',
         ],
         # There is no expection file for dawn_end2end_tests. The expectations will be used to suppress the dawn e2e failures in test report.
         # Example: '[ Util.HOST_OS ] ComputeStorageBufferBarrierTests.UniformToStorageAddPingPong/D3D11_Intel_R_Arc_TM_A770_Graphics'


### PR DESCRIPTION
These tests are expected failures and skipped in Chromium trybots due to video codec is not supported. They are not skipped in our daily tests becuase we build chromium with 'proprietary_codecs = true'.

Expect them failure in daily tests so we can know when they're fixed.