### PR TITLE
mesa.py: Update build dependences for Mesa 24.3

### DIFF
--- a/misc/mesa.py
+++ b/misc/mesa.py
@@ -88,7 +88,7 @@ examples:
         print(Util.HOST_OS_RELEASE)
         if Util.HOST_OS == 'linux' and Util.HOST_OS_RELEASE == 'ubuntu':
             Util.ensure_pkg(
-                'meson python3-mako glslang-tools libomxil-bellagio-dev libpciaccess-dev libclc-18-dev libclc-18 libllvmspirvlib-18-dev libclang-18-dev'
+                'meson python3-mako glslang-tools libomxil-bellagio-dev libpciaccess-dev libclc-19-dev libclc-19 libllvmspirvlib-19-dev libclang-19-dev'
             )
             # x11
             Util.ensure_pkg(


### PR DESCRIPTION
The building of Mesa 24.3 requires libllvmspirvlib >= 19.0.

libomxil-bellagio-dev is not available on Ubuntu 24.10 yet, see https://launchpad.net/ubuntu/+source/libomxil-bellagio. We need to install it manually from http://archive.ubuntu.com/ubuntu/pool/universe/libo/libomxil-bellagio/.